### PR TITLE
Support lookup with specific locale

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', ['umd', 'karma', 'uglify:foreigner', 'uglify:foreigner_min']);
   grunt.registerTask('test', ['umd', 'karma']);
-  grunt.registerTask('test:coverage', ['karma', 'coveralls']);
+  grunt.registerTask('test:coverage', ['umd', 'karma', 'coveralls']);
 
   grunt.loadNpmTasks('grunt-umd');
   grunt.loadNpmTasks('grunt-karma');

--- a/lib/foreigner.js
+++ b/lib/foreigner.js
@@ -21,14 +21,14 @@ var NUMBER_MAP = {
   '2': 'two'
 };
 
-var lookupKey = function(key) {
-  var string = (key.indexOf('.') >= 0) ? lookupKeyPath(key) : lookupSimpleKey(key);
-  return (string) ? lookupAlias(string) : null;
+var lookupKey = function(key, locale) {
+  var string = (key.indexOf('.') >= 0) ? lookupKeyPath(key, locale) : lookupSimpleKey(key, locale);
+  return (string) ? lookupAlias(string, locale) : null;
 };
 
-var lookupKeyPath = function(keyPath) {
+var lookupKeyPath = function(keyPath, locale) {
   var paths = keyPath.split('.');
-  var value = foreigner.translations[foreigner.locale];
+  var value = foreigner.translations[locale];
 
   var index = 0;
   while (index < paths.length && value) {
@@ -40,13 +40,13 @@ var lookupKeyPath = function(keyPath) {
   return value;
 };
 
-var lookupSimpleKey = function(key) {
-  return foreigner.translations[foreigner.locale][key];
+var lookupSimpleKey = function(key, locale) {
+  return foreigner.translations[locale][key];
 };
 
-var lookupAlias = function(string) {
+var lookupAlias = function(string, locale) {
   while (typeof string === 'string' && string.charAt(0) === '!') {
-    string = lookupKey(string.slice(1));
+    string = lookupKey(string.slice(1), locale);
   }
 
   return string;
@@ -123,11 +123,19 @@ foreigner = {
   translations: {},
 
   t: function(key, attrs) {
-    if (!foreigner.locale) {
-      throw new Error('[foreigner] You tried to lookup a translation before setting a locale.');
+    var locale = foreigner.locale;
+
+    if (arguments.length === 2 && typeof attrs === 'string') {
+      locale = attrs;
+    } else if (arguments.length === 3) {
+      locale = arguments[2];
     }
 
-    var string = lookupKey(key);
+    if (!locale) {
+      throw new Error('[foreigner] You tried to lookup a translation without setting a locale.');
+    }
+
+    var string = lookupKey(key, locale);
 
     if (!string) return null;
 

--- a/test/key_lookup_spec.js
+++ b/test/key_lookup_spec.js
@@ -15,6 +15,11 @@ describe('Key lookup', function() {
       tristram_portal: '!magic_portal',
       weekdays: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
     };
+
+    foreigner.translations.special = {
+      testing: 'Testing',
+      testing_interpolation: 'Testing {thing}'
+    };
   });
 
   afterEach(function() {
@@ -51,5 +56,10 @@ describe('Key lookup', function() {
     expect(function() { foreigner.t('weekdays'); }).not.toThrow();
     expect(Array.isArray(foreigner.t('weekdays'))).toBe(true);
     expect(foreigner.t('weekdays')[0]).toEqual('Sunday');
+  });
+
+  it('should be able to lookup a key in a specific locale', function() {
+    expect(foreigner.t('testing', 'special')).toEqual('Testing');
+    expect(foreigner.t('testing_interpolation', {thing: 'something'}, 'special')).toEqual('Testing something');
   });
 });


### PR DESCRIPTION
It’s now possible to do:

```js
foreigner.t('key', 'locale');
foreigner.t('key2', {interpolation: 'value'}, locale);
```